### PR TITLE
Add summary statistics helpers and simulation examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,26 @@ This project follows a lightweight changelog format inspired by [Keep a Changelo
 
 ## [Unreleased]
 
+### Added
+
+* Added `mode(array)`.
+* Added `range(array)`.
+* Added `iqr(array)`.
+* Added `percentile(array, p)`.
+* Added `summary(array)`.
+* Added `examples/weighted_loot_drop.lua`.
+* Added `examples/monte_carlo_pi.lua`.
+* Added `examples/poisson_arrivals.lua`.
+* Added `examples/binomial_coin_flips.lua`.
+* Added `examples/bootstrap_mean.lua`.
+
 ### Planned
 
-* Continue improving documentation and examples.
-* Add manual GitHub Actions CI.
-* Add LuaRocks validation and publishing workflow improvements.
-* Consider additional statistics helpers and distribution examples.
+* Improve GitHub Actions CI with optional automatic checks for pull requests.
+* Improve LuaRocks validation and publishing workflows.
+* Add more distribution examples and simulation-oriented examples.
+* Explore a lightweight cross-reference with LuaHMF as a related pure-Lua math helper project.
+* Evaluate future combinatorics helpers such as `factorial`, `combinations`, and `permutations`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The project started around 2014 and was later published under the MIT License. I
 * Lua 5.1+ friendly
 * Single-file friendly
 * Basic descriptive statistics
+* Summary statistics helpers
 * Sampling utilities
 * Discrete and continuous pseudo-random variables
 * Compatible with the existing public LuaSF API
@@ -107,6 +108,7 @@ print(stats.mean(values))     -- 3
 print(stats.stddev(values))   -- sample standard deviation
 print(stats.median(values))   -- 3
 print(stats.variance(values)) -- sample variance
+print(stats.summary(values).count) -- 5
 ```
 
 Legacy names are still available:
@@ -138,13 +140,18 @@ print(stats.stvF(values)) -- sample standard deviation
 
 ### Additional descriptive statistics
 
-| Function             | Description                         |
-| -------------------- | ----------------------------------- |
-| `variance(array)`    | Sample variance using `n - 1`       |
-| `median(array)`      | Median value                        |
-| `min(array)`         | Minimum value                       |
-| `max(array)`         | Maximum value                       |
-| `quantile(array, q)` | Quantile using linear interpolation |
+| Function               | Description                                                            |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `variance(array)`      | Sample variance using `n - 1`                                          |
+| `median(array)`        | Median value                                                           |
+| `min(array)`           | Minimum value                                                          |
+| `max(array)`           | Maximum value                                                          |
+| `quantile(array, q)`   | Quantile using linear interpolation                                    |
+| `mode(array)`          | Most frequent value                                                    |
+| `range(array)`         | Difference between maximum and minimum                                 |
+| `iqr(array)`           | Interquartile range                                                    |
+| `percentile(array, p)` | Percentile where `p` is between `0` and `100`                          |
+| `summary(array)`       | Summary table with count, min, max, mean, median, variance, and stddev |
 
 ### Sampling utilities
 
@@ -200,6 +207,23 @@ local frequencies = stats.frequency(rolls)
 for i = 1, #frequencies.counts do
   print("Frequency - Sum Number:", frequencies.values[i], frequencies.counts[i])
 end
+```
+
+### Summary statistics
+
+```lua
+local stats = require("luasf")
+
+local values = {10, 12, 14, 15, 18, 20}
+local result = stats.summary(values)
+
+print("Count:", result.count)
+print("Min:", result.min)
+print("Max:", result.max)
+print("Mean:", result.mean)
+print("Median:", result.median)
+print("Variance:", result.variance)
+print("Stddev:", result.stddev)
 ```
 
 ### Normal distribution quality control sample
@@ -277,6 +301,11 @@ LuaSF/
     dice_simulation.lua
     normal_quality_control.lua
     gamma_distribution.lua
+    weighted_loot_drop.lua
+    monte_carlo_pi.lua
+    poisson_arrivals.lua
+    binomial_coin_flips.lua
+    bootstrap_mean.lua
   docs/
     api.md
   .github/
@@ -320,6 +349,11 @@ lua spec/test_sampling.lua
 lua examples/dice_simulation.lua
 lua examples/normal_quality_control.lua
 lua examples/gamma_distribution.lua
+lua examples/weighted_loot_drop.lua
+lua examples/monte_carlo_pi.lua
+lua examples/poisson_arrivals.lua
+lua examples/binomial_coin_flips.lua
+lua examples/bootstrap_mean.lua
 ```
 
 ---
@@ -342,11 +376,12 @@ lua examples/gamma_distribution.lua
 
 ### Planned
 
-* Manual GitHub Actions CI
-* LuaRocks package validation workflow
+* Improve GitHub Actions CI with optional automatic checks for pull requests
+* Improve LuaRocks validation and publishing workflows
 * More examples
 * More statistical helpers
-* Optional documentation generation
+* Lightweight cross-reference with LuaHMF
+* Future combinatorics helpers such as `factorial`, `combinations`, and `permutations`
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -195,6 +195,101 @@ print(stats.quantile({1, 2, 3, 4, 5}, 0.5)) -- 3
 
 ---
 
+### `mode(array)`
+
+Returns the most frequent value in an array.
+
+If multiple values have the same frequency, LuaSF returns the first mode found after sorting the values.
+
+```lua
+local stats = require("luasf")
+
+print(stats.mode({1, 2, 2, 3})) -- 2
+```
+
+---
+
+### `range(array)`
+
+Returns the difference between the maximum and minimum values.
+
+```lua
+local stats = require("luasf")
+
+print(stats.range({3, 1, 10, 2})) -- 9
+```
+
+---
+
+### `iqr(array)`
+
+Returns the interquartile range.
+
+It is calculated as:
+
+```text
+quantile(array, 0.75) - quantile(array, 0.25)
+```
+
+Example:
+
+```lua
+local stats = require("luasf")
+
+print(stats.iqr({1, 2, 3, 4, 5})) -- 2
+```
+
+---
+
+### `percentile(array, p)`
+
+Returns the `p` percentile.
+
+`p` must be between `0` and `100`.
+
+```lua
+local stats = require("luasf")
+
+print(stats.percentile({1, 2, 3, 4, 5}, 50)) -- 3
+```
+
+---
+
+### `summary(array)`
+
+Returns a summary table with common descriptive statistics.
+
+The returned table includes:
+
+```lua
+{
+  count = number,
+  min = number,
+  max = number,
+  mean = number,
+  median = number,
+  variance = number or nil,
+  stddev = number or nil
+}
+```
+
+Example:
+
+```lua
+local stats = require("luasf")
+
+local result = stats.summary({1, 2, 3, 4, 5})
+
+print(result.count)    -- 5
+print(result.min)      -- 1
+print(result.max)      -- 5
+print(result.mean)     -- 3
+print(result.median)   -- 3
+print(result.variance) -- 2.5
+```
+
+---
+
 ## Sampling utilities
 
 ### `choice(array)`
@@ -673,6 +768,11 @@ stats.median
 stats.min
 stats.max
 stats.quantile
+stats.mode
+stats.range
+stats.iqr
+stats.percentile
+stats.summary
 stats.choice
 stats.shuffle
 stats.sample

--- a/examples/binomial_coin_flips.lua
+++ b/examples/binomial_coin_flips.lua
@@ -1,0 +1,10 @@
+local stats = require("luasf")
+
+local flips = 10
+local probability_heads = 0.5
+local experiments = 20
+
+for i = 1, experiments do
+  local heads = stats.binomial(flips, probability_heads)
+  print("Experiment:", i, "Heads:", heads)
+end

--- a/examples/bootstrap_mean.lua
+++ b/examples/bootstrap_mean.lua
@@ -1,0 +1,25 @@
+local stats = require("luasf")
+
+local values = {10, 12, 14, 15, 18, 20}
+local bootstrap_means = {}
+local bootstrap_runs = 1000
+
+for run = 1, bootstrap_runs do
+  local sample = {}
+
+  for i = 1, #values do
+    sample[i] = stats.choice(values)
+  end
+
+  bootstrap_means[run] = stats.mean(sample)
+end
+
+local result = stats.summary(bootstrap_means)
+
+print("Bootstrap mean summary")
+print("Count:", result.count)
+print("Min:", result.min)
+print("Max:", result.max)
+print("Mean:", result.mean)
+print("Median:", result.median)
+print("Stddev:", result.stddev)

--- a/examples/monte_carlo_pi.lua
+++ b/examples/monte_carlo_pi.lua
@@ -1,0 +1,17 @@
+local stats = require("luasf")
+
+local trials = 100000
+local inside = 0
+
+for _ = 1, trials do
+  local x = stats.uniform(-1, 1)
+  local y = stats.uniform(-1, 1)
+
+  if x * x + y * y <= 1 then
+    inside = inside + 1
+  end
+end
+
+local pi_estimate = 4 * inside / trials
+
+print("Pi estimate:", pi_estimate)

--- a/examples/poisson_arrivals.lua
+++ b/examples/poisson_arrivals.lua
@@ -1,0 +1,9 @@
+local stats = require("luasf")
+
+local lambda = 3
+local periods = 20
+
+for period = 1, periods do
+  local arrivals = stats.poisson(lambda)
+  print("Period:", period, "Arrivals:", arrivals)
+end

--- a/examples/weighted_loot_drop.lua
+++ b/examples/weighted_loot_drop.lua
@@ -1,0 +1,16 @@
+local stats = require("luasf")
+
+local items = {"common", "rare", "epic", "legendary"}
+local weights = {80, 15, 4, 1}
+
+local drops = {}
+
+for i = 1, 1000 do
+  drops[i] = stats.weighted_choice(items, weights)
+end
+
+local frequencies = stats.frequency(drops)
+
+for i = 1, #frequencies.values do
+  print(frequencies.values[i], frequencies.counts[i])
+end

--- a/luasf-0.4.0-1.rockspec
+++ b/luasf-0.4.0-1.rockspec
@@ -1,0 +1,32 @@
+package = "luasf"
+version = "0.4.0-1"
+
+source = {
+  url = "git://github.com/HubertRonald/LuaSF.git",
+  tag = "v0.4.0"
+}
+
+description = {
+  summary = "Lua Statistics Functions",
+  detailed = [[
+LuaSF is a lightweight, pure-Lua library for descriptive statistics,
+summary statistics, sampling utilities, simulation examples, and random
+variable generation.
+  ]],
+  homepage = "https://github.com/HubertRonald/LuaSF",
+  license = "MIT",
+  maintainer = "Hubert Ronald"
+}
+
+dependencies = {
+  "lua >= 5.1"
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    luasf = "src/luasf.lua",
+    LuaSF = "LuaSF.lua",
+    LuaStat = "LuaStat.lua"
+  }
+}

--- a/spec/test_stats.lua
+++ b/spec/test_stats.lua
@@ -74,4 +74,31 @@ function TestStats:test_quantile()
   luaunit.assertEquals(stats.quantile({1, 2, 3, 4, 5}, 0.5), 3)
 end
 
+function TestStats:test_mode()
+  luaunit.assertEquals(stats.mode({1, 2, 2, 3}), 2)
+end
+
+function TestStats:test_range()
+  luaunit.assertEquals(stats.range({3, 1, 10, 2}), 9)
+end
+
+function TestStats:test_iqr()
+  luaunit.assertEquals(stats.iqr({1, 2, 3, 4, 5}), 2)
+end
+
+function TestStats:test_percentile()
+  luaunit.assertEquals(stats.percentile({1, 2, 3, 4, 5}, 50), 3)
+end
+
+function TestStats:test_summary()
+  local result = stats.summary({1, 2, 3, 4, 5})
+
+  luaunit.assertEquals(result.count, 5)
+  luaunit.assertEquals(result.min, 1)
+  luaunit.assertEquals(result.max, 5)
+  luaunit.assertEquals(result.mean, 3)
+  luaunit.assertEquals(result.median, 3)
+  luaunit.assertAlmostEquals(result.variance, 2.5, 0.000001)
+end
+
 os.exit(luaunit.LuaUnit.run())

--- a/src/luasf.lua
+++ b/src/luasf.lua
@@ -255,6 +255,60 @@ local function frecuencyF(array)
   }
 end
 
+local function mode(array)
+  assert_non_empty_array(array)
+
+  local freq = frecuencyF(array)
+  local best_value = freq.g[1]
+  local best_count = freq.c[1]
+
+  for i = 2, #freq.g do
+    if freq.c[i] > best_count then
+      best_value = freq.g[i]
+      best_count = freq.c[i]
+    end
+  end
+
+  return best_value
+end
+
+local function range_value(array)
+  return max_value(array) - min_value(array)
+end
+
+local function iqr(array)
+  return quantile(array, 0.75) - quantile(array, 0.25)
+end
+
+local function percentile(array, p)
+  assert_number(p, "p")
+  assert(p >= 0 and p <= 100, "p must be between 0 and 100")
+
+  return quantile(array, p / 100)
+end
+
+local function summary(array)
+  assert_non_empty_array(array)
+
+  local result = {
+    count = #array,
+    min = min_value(array),
+    max = max_value(array),
+    mean = avF(array),
+    median = median(array)
+  }
+
+  if #array >= 2 then
+    result.variance = variance(array)
+    result.stddev = stvF(array)
+  else
+    result.variance = nil
+    result.stddev = nil
+  end
+
+  return result
+end
+
 -- Normal random variable.
 -- Original approximation method kept for compatibility.
 local function normalVA(mu, sig)
@@ -586,6 +640,13 @@ M.sum = sumF
 M.mean = avF
 M.stddev = stvF
 M.frequency = frecuencyF
+
+M.mode = mode
+M.range = range_value
+M.iqr = iqr
+M.percentile = percentile
+M.summary = summary
+
 M.normal = normalVA
 M.inverse_normal = normal_inv_D
 M.bernoulli = bernoulliVA


### PR DESCRIPTION
## Summary

This PR adds a new LuaSF improvement phase focused on summary statistics helpers and simulation-oriented examples.

The goal is to make LuaSF more useful for teaching, scripting, lightweight data analysis, simulations, and game/modding scenarios while preserving the existing public API and compatibility entry points.

## What changed

### Added summary statistics helpers

Added the following modern API functions:

- `mode(array)`
- `range(array)`
- `iqr(array)`
- `percentile(array, p)`
- `summary(array)`

The new `summary(array)` helper returns a compact table with common descriptive statistics:

```lua
{
  count = 5,
  min = 1,
  max = 5,
  mean = 3,
  median = 3,
  variance = 2.5,
  stddev = 1.5811
}
````

### Added simulation-oriented examples

Added new examples under `examples/`:

* `examples/weighted_loot_drop.lua`
* `examples/monte_carlo_pi.lua`
* `examples/poisson_arrivals.lua`
* `examples/binomial_coin_flips.lua`
* `examples/bootstrap_mean.lua`

These examples are intended to make LuaSF easier to understand and more useful for practical simulation, teaching, and scripting scenarios.

### Added tests

Updated `spec/test_stats.lua` with tests for the new summary statistics helpers.

The new tests cover:

* `mode(array)`
* `range(array)`
* `iqr(array)`
* `percentile(array, p)`
* `summary(array)`

### Documentation

Updated documentation to include the new helpers and examples:

* Updated `README.md`
* Updated `docs/api.md`
* Updated `CHANGELOG.md`

### LuaRocks preparation

Added a new rockspec draft for the next release:

* `luasf-0.4.0-1.rockspec`

This prepares the project for:

```text
v0.4.0 - Summary Statistics and Simulation Examples
```

## Compatibility notes

This PR does not remove or rename existing public functions.

The existing legacy API remains available, including:

```lua
stats.sumF(array)
stats.avF(array)
stats.stvF(array)
stats.frecuencyF(array)
stats.nomalVA(mu, sig)
stats.normalVA(mu, sig)
stats.normal_inv_D(p, mu, sig)
stats.bernoulliVA(p)
stats.unifVA(min, max)
stats.expoVA(beta)
stats.weibullVA(alpha, beta)
stats.erlangVA(n, lambda)
stats.trianVA(a, b, c)
stats.binomialVA(n, p)
stats.geometricVA(p)
stats.poissonVA(lambda)
stats.chiSquareVA(n)
stats.gamVA(alpha, lambda)
stats.lognoVA(m, s)
stats.lognoRandVA(m, s)
```

The new functions are added as modern API helpers only.

## Testing

Tested locally with:

```bash
lua spec/test_stats.lua
lua spec/test_distributions.lua
lua spec/test_sampling.lua
```

Examples can be run with:

```bash
lua examples/weighted_loot_drop.lua
lua examples/monte_carlo_pi.lua
lua examples/poisson_arrivals.lua
lua examples/binomial_coin_flips.lua
lua examples/bootstrap_mean.lua
```

## Release target

After this PR is merged into `master`, the next release target is:

```text
LuaSF v0.4.0 - Summary Statistics and Simulation Examples
```

Recommended tag after merge:

```bash
git checkout master
git pull origin master

git tag -a v0.4.0 -m "LuaSF v0.4.0 - Summary Statistics and Simulation Examples"
git push origin v0.4.0
```