### PR TITLE
Improve CI and LuaRocks manual publishing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: CI
 on:
   workflow_dispatch:
 
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "src/**"
+      - "spec/**"
+      - "examples/**"
+      - "LuaSF.lua"
+      - "LuaStat.lua"
+      - "*.rockspec"
+      - ".github/workflows/ci.yml"
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lua ${{ matrix.lua-version }}
@@ -20,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Lua
         uses: leafo/gh-actions-lua@v13
@@ -44,3 +59,8 @@ jobs:
           lua examples/dice_simulation.lua
           lua examples/normal_quality_control.lua
           lua examples/gamma_distribution.lua
+          lua examples/weighted_loot_drop.lua
+          lua examples/monte_carlo_pi.lua
+          lua examples/poisson_arrivals.lua
+          lua examples/binomial_coin_flips.lua
+          lua examples/bootstrap_mean.lua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Install test dependencies
         run: luarocks install luaunit
 
+      - name: Configure local Lua module path
+        run: echo "LUA_PATH=./src/?.lua;./?.lua;${LUA_PATH}" >> "$GITHUB_ENV"
+
       - name: Run tests
         run: |
           lua spec/test_stats.lua

--- a/.github/workflows/publish-luarocks.yml
+++ b/.github/workflows/publish-luarocks.yml
@@ -4,9 +4,22 @@ on:
   workflow_dispatch:
     inputs:
       rockspec:
-        description: "Rockspec file to validate"
+        description: "Rockspec file to validate or publish"
         required: true
-        default: "luasf-0.3.0-1.rockspec"
+        default: "luasf-0.4.0-1.rockspec"
+        type: string
+      publish:
+        description: "Publish to LuaRocks after validation"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: luarocks-publish
+  cancel-in-progress: false
 
 jobs:
   validate:
@@ -15,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Lua
         uses: leafo/gh-actions-lua@v13
@@ -26,10 +39,38 @@ jobs:
         uses: leafo/gh-actions-luarocks@v6
 
       - name: Validate rockspec
-        run: luarocks lint "${{ github.event.inputs.rockspec }}"
+        run: luarocks lint "${{ inputs.rockspec }}"
 
       - name: Build rock locally
-        run: luarocks make "${{ github.event.inputs.rockspec }}"
+        run: luarocks make "${{ inputs.rockspec }}"
+
+      - name: Test LuaRocks package entry point
+        run: lua -e 'local stats = require("luasf"); print(stats.sum({1,2,3}))'
+
+      - name: Test LuaSF compatibility entry point
+        run: lua -e 'local stats = require("LuaSF"); print(stats.sumF({1,2,3}))'
+
+      - name: Test LuaStat compatibility entry point
+        run: lua -e 'local stats = require("LuaStat"); print(stats.avF({2,4,6}))'
+
+  publish:
+    name: Publish to LuaRocks
+    needs: validate
+    runs-on: ubuntu-latest
+    if: ${{ inputs.publish == true }}
+    environment: luarocks-production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: "5.4.8"
+
+      - name: Set up LuaRocks
+        uses: leafo/gh-actions-luarocks@v6
 
       - name: Upload to LuaRocks
-        run: luarocks upload "${{ github.event.inputs.rockspec }}" --api-key="${{ secrets.LUAROCKS_API_KEY }}"
+        run: luarocks upload "${{ inputs.rockspec }}" --api-key="${{ secrets.LUAROCKS_API_KEY }}"


### PR DESCRIPTION
## Summary

This PR improves the GitHub Actions workflows for LuaSF by making CI more focused and LuaRocks publishing safer.

The main goal is to avoid accidental package publishing while keeping a clean manual workflow for validating and publishing LuaRocks releases.

## What changed

### CI workflow

Updated `.github/workflows/ci.yml` to:

- Run manually through `workflow_dispatch`.
- Run automatically on pull requests to `master`.
- Use path filters so CI only runs when relevant files change.
- Test LuaSF across multiple Lua versions.
- Run the full test suite.
- Run the example scripts.

The CI workflow now focuses on relevant project files such as:

- `src/**`
- `spec/**`
- `examples/**`
- `LuaSF.lua`
- `LuaStat.lua`
- `*.rockspec`
- `.github/workflows/ci.yml`

This avoids triggering CI for unrelated documentation-only changes unless the workflow is manually executed.

### LuaRocks publishing workflow

Updated `.github/workflows/publish-luarocks.yml` to keep publishing manual and protected.

The workflow now supports:

- Manual execution through `workflow_dispatch`.
- A configurable `rockspec` input.
- A `publish` boolean input.
- Validation-only mode by default.
- Optional publishing only when `publish = true`.
- Rockspec validation with `luarocks lint`.
- Local package build with `luarocks make`.
- Runtime checks for:
  - `require("luasf")`
  - `require("LuaSF")`
  - `require("LuaStat")`

### Safety improvements

Publishing to LuaRocks is now protected by several safeguards:

- The workflow does not run on push.
- The workflow does not run on pull requests.
- The workflow does not run automatically on tags or releases.
- Publishing is disabled by default with `publish = false`.
- Publishing only happens when manually enabled with `publish = true`.
- The publish job uses the `luarocks-production` environment for an additional approval layer.
- The LuaRocks API key remains protected through the `LUAROCKS_API_KEY` GitHub Actions secret.

## Why this matters

LuaSF is now published on LuaRocks, so publishing must be handled carefully.

This PR ensures that normal development activity, documentation changes, or merges into `master` do not accidentally publish a new LuaRocks package.

## How to validate

Run CI manually from GitHub Actions:

```text
Actions -> CI -> Run workflow
````

Validate the LuaRocks package without publishing:

```text
Actions -> Publish to LuaRocks -> Run workflow
rockspec: luasf-0.4.0-1.rockspec
publish: false
```

Publish only when intentionally needed:

```text
Actions -> Publish to LuaRocks -> Run workflow
rockspec: luasf-0.4.0-1.rockspec
publish: true
```

When `publish = true`, GitHub should require approval through the `luarocks-production` environment before uploading to LuaRocks.

## Notes

This PR only updates CI/CD and publishing workflows.

It does not change LuaSF library code, tests, examples, documentation, or public API behavior.